### PR TITLE
auth: allow internal users to manage teams and vector stores

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -589,6 +589,19 @@ class LiteLLMRoutes(enum.Enum):
 
     internal_user_routes = (
         [
+            "/team/new",
+            "/team/list",
+            "/team/info",
+            "/team/update",
+            "/team/delete",
+            "/vector_store/new",
+            "/vector_store/list",
+            "/vector_store/info",
+            "/vector_store/update",
+            "/vector_store/delete",
+            "/vector_store/qdrant/create_collection",
+            "/vector_store/qdrant/collection/info",
+            "/vector_store/qdrant/collection/points",
             "/global/spend/tags",
             "/global/spend/keys",
             "/global/spend/models",

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -325,10 +325,20 @@ async def new_vector_store(
                 detail=f"Vector store with ID {vector_store.get('vector_store_id')} already exists",
             )
 
-        if vector_store.get("vector_store_metadata") is not None:
-            vector_store["vector_store_metadata"] = safe_dumps(
-                vector_store.get("vector_store_metadata")
-            )
+        vector_store_metadata = vector_store.get("vector_store_metadata") or {}
+        if isinstance(vector_store_metadata, str):
+            try:
+                vector_store_metadata = json.loads(vector_store_metadata)
+            except Exception:
+                vector_store_metadata = {}
+
+        if user_api_key_dict.user_id and not vector_store_metadata.get("created_by"):
+            vector_store_metadata["created_by"] = user_api_key_dict.user_id
+        if user_api_key_dict.team_id and not vector_store_metadata.get("team_id"):
+            vector_store_metadata["team_id"] = user_api_key_dict.team_id
+
+        if vector_store_metadata:
+            vector_store["vector_store_metadata"] = safe_dumps(vector_store_metadata)
 
         # Safely handle JSON serialization of litellm_params
         litellm_params_json: Optional[str] = None
@@ -1132,6 +1142,41 @@ async def list_vector_stores(
                     )
 
         combined_vector_stores = list(vector_store_map.values())
+
+        if user_api_key_dict.user_role not in [
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+            LitellmUserRoles.ORG_ADMIN,
+        ]:
+            team_ids: set[str] = set()
+            if user_api_key_dict.team_id:
+                team_ids.add(user_api_key_dict.team_id)
+            if user_api_key_dict.user_id:
+                team_memberships = await prisma_client.db.litellm_teammembership.find_many(
+                    where={"user_id": user_api_key_dict.user_id}
+                )
+                team_ids.update({tm.team_id for tm in team_memberships if tm.team_id})
+
+            def _has_access(vector_store: LiteLLM_ManagedVectorStore) -> bool:
+                metadata = vector_store.get("vector_store_metadata") or {}
+                if isinstance(metadata, str):
+                    try:
+                        metadata = json.loads(metadata)
+                    except Exception:
+                        metadata = {}
+                if not isinstance(metadata, dict):
+                    return False
+                created_by = metadata.get("created_by")
+                team_id = metadata.get("team_id")
+                if user_api_key_dict.user_id and created_by == user_api_key_dict.user_id:
+                    return True
+                if team_id and team_id in team_ids:
+                    return True
+                return False
+
+            combined_vector_stores = [
+                vector_store for vector_store in combined_vector_stores if _has_access(vector_store)
+            ]
         total_count = len(combined_vector_stores)
         total_pages = (total_count + page_size - 1) // page_size
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/TeamsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/TeamsView.tsx
@@ -4,7 +4,7 @@ import { fetchTeams } from "@/components/common_components/fetch_teams";
 import { Form } from "antd";
 import TeamInfoView from "@/components/team/team_info";
 import TeamSSOSettings from "@/components/TeamSSOSettings";
-import { isAdminRole } from "@/utils/roles";
+import { canCreateTeams, isAdminRole } from "@/utils/roles";
 import { Card, Button, Col, Text, Grid, TabPanel } from "@tremor/react";
 import AvailableTeamsPanel from "@/components/team/available_teams";
 import type { KeyResponse, Team } from "@/components/key_team_helpers/key_list";
@@ -245,7 +245,7 @@ const TeamsView: React.FC<TeamProps> = ({
     <div className="w-full mx-4 h-[75vh]">
       <Grid numItems={1} className="gap-2 p-8 w-full mt-2">
         <Col numColSpan={1} className="flex flex-col gap-2">
-          {(userRole == "Admin" || userRole == "Org Admin") && (
+          {canCreateTeams(userRole || "") && (
             <Button className="w-fit" onClick={() => setIsTeamModalVisible(true)}>
               + Create New Team
             </Button>
@@ -335,7 +335,7 @@ const TeamsView: React.FC<TeamProps> = ({
               )}
             </TeamsHeaderTabs>
           )}
-          {(userRole == "Admin" || userRole == "Org Admin") && (
+          {canCreateTeams(userRole || "") && (
             <CreateTeamModal
               isTeamModalVisible={isTeamModalVisible}
               handleOk={handleOk}

--- a/ui/litellm-dashboard/src/components/vector_store_management/index.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_management/index.tsx
@@ -18,7 +18,7 @@ import VectorStoreForm from "./VectorStoreForm";
 import DeleteResourceModal from "../common_components/DeleteResourceModal";
 import VectorStoreInfoView from "./vector_store_info";
 import VectorStoreCollectionView from "./VectorStoreCollectionView";
-import { isAdminRole } from "@/utils/roles";
+import { canManageVectorStores } from "@/utils/roles";
 import NotificationsManager from "../molecules/notifications_manager";
 
 interface VectorStoreProps {
@@ -251,7 +251,7 @@ const VectorStoreManagement: React.FC<VectorStoreProps> = ({ accessToken, userID
         vectorStoreId={selectedVectorStoreId}
         onClose={handleCloseInfo}
         accessToken={accessToken}
-        is_admin={isAdminRole(userRole || "")}
+        is_admin={canManageVectorStores(userRole || "")}
         editVectorStore={editVectorStore}
       />
     </div>

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -8,10 +8,19 @@ export const all_admin_roles = [...old_admin_roles, ...v2_admin_role_names];
 export const internalUserRoles = ["Internal User", "Internal Viewer"];
 export const rolesAllowedToSeeUsage = ["Admin", "Admin Viewer", "Internal User", "Internal Viewer"];
 export const rolesWithWriteAccess = ["Internal User", "Admin", "proxy_admin"];
+export const internalWriteRoles = ["Internal User"];
 
 // Helper function to check if a role is in all_admin_roles
 export const isAdminRole = (role: string): boolean => {
   return all_admin_roles.includes(role);
+};
+
+export const canCreateTeams = (role: string): boolean => {
+  return isAdminRole(role) || internalWriteRoles.includes(role);
+};
+
+export const canManageVectorStores = (role: string): boolean => {
+  return isAdminRole(role) || internalWriteRoles.includes(role);
 };
 
 export const isProxyAdminRole = (role: string): boolean => {


### PR DESCRIPTION
## Relevant issues
#11 

## Type
🆕 New Feature
🧹 Refactoring

## Changes

Allow internal users to create/manage teams
Allow internal users to create/manage vector stores
Restrict vector store list to the user’s own stores + team stores
UI: enable team/vector store actions for internal users


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Internal users now have access to additional team and vector store management endpoints

* **Bug Fixes**
  * Vector store metadata is now automatically attributed to creators and teams
  * Vector stores are now properly filtered based on user access permissions
  * Team and vector store creation permissions are now correctly enforced by role

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->